### PR TITLE
Fix release build crash

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -32,3 +32,13 @@
 -dontwarn com.squareup.okhttp.**
 
 -keepnames class * extends java.lang.Exception
+
+#Conductor rules
+# Retain constructor that is called by using reflection to recreate the Controller
+-keepclassmembers public class * extends com.bluelinelabs.conductor.Controller {
+   public <init>();
+   public <init>(android.os.Bundle);
+}
+-keepclassmembers public class * extends com.bluelinelabs.conductor.ControllerChangeHandler {
+   public <init>();
+}


### PR DESCRIPTION
Fix #28 caused by ProGuard removing a constructor
that was called via reflection.